### PR TITLE
Supply Windows-idiomatic electrum user data path.

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -139,7 +139,7 @@ you first run the application and located under the /wallets folder.
 On Windows:
 
  - Show hidden files
- - Go to \Users\YourUserName\AppData\Roaming\Local\Electrum
+ - Go to %APPDATA%\\Electrum
 
 On Mac:
 


### PR DESCRIPTION
In the FAQ, for Windows, the path to the directory containing the electrum wallet is garbled. This commit fixes the backslash problem and provides a more Windows-idiomatic path, using %APPDATA%.
