### PR TITLE
Update faq.rst

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -139,7 +139,7 @@ you first run the application and located under the /wallets folder.
 On Windows:
 
  - Show hidden files
- - Go to \Users\YourUserName\AppData\Roaming\Local\Electrum
+ - Go to \Users\YourUserName\AppData\Roaming\Electrum\wallets
 
 On Mac:
 


### PR DESCRIPTION
Corrected by deleting the word "Local" and adding the word "\wallets" in following sentence:
(concerns location of the wallet on Windows)

Go to \Users\YourUserName\AppData\Roaming\Electrum\wallets