### PR TITLE
protocol.rst: state version of protocol explained

### DIFF
--- a/protocol.rst
+++ b/protocol.rst
@@ -69,6 +69,9 @@ version of the protocol it supports. Server responds with its
 supported version of the protocol (higher number at server-side is
 usually compatible).
 
+The version of the protocol being explained in this documentation
+is: 0.10.
+
 *request:*
 
 .. code-block:: json


### PR DESCRIPTION
If anyone were to understand how to use the server.version method, they would need to know the exact version of the protocol they are using, and to know that, the documentation should explicitly state it, itself.

Last change of the announced version of the protocol in electrum is 0.10:
https://github.com/spesmilo/electrum/commit/118052d81597eff3eb636d242eacdd0437dabdd6