### PR TITLE
update wallet location on windows

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -161,7 +161,7 @@ you first run the application and located under the /wallets folder.
 On Windows:
 
  - Show hidden files
- - Go to \Users\YourUserName\AppData\Roaming\Electrum\wallets
+ - Go to \\Users\\YourUserName\\AppData\\Roaming\\Electrum\\wallets (or %APPDATA%\\Electrum\\wallets)
 
 On Mac:
 


### PR DESCRIPTION
- backslashes were not visible in markdown rendering
- Windows has a well-known environment variable (APPDATA) that can be used without needing to know your username