### PR TITLE
Remove real address from sweep

### DIFF
--- a/cmdline.rst
+++ b/cmdline.rst
@@ -208,4 +208,4 @@ command:
 
 .. code-block:: bash
 
-   electrum listaddresses --funded | electrum getprivatekeys - | jq 'map(.[0])' | electrum sweep - 1uCMeviLYzwWh1P2gEh3R4X34ArzVUR1R
+   electrum listaddresses --funded | electrum getprivatekeys - | jq 'map(.[0])' | electrum sweep - [destination address]


### PR DESCRIPTION
If someone were to copy/paste the example for sweeping coins, they'd get sent to a real address they don't control.