### PR TITLE
Minor fixes for grammar and consistency in the FAQ

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -17,7 +17,7 @@ Not really; the Electrum client never sends private keys
 to the servers. In addition, it verifies the information
 reported by servers, using a technique called :ref:`Simple Payment Verification <spv>`
 
-What is the Seed?
+What is the seed?
 -----------------
 
 The seed is a random phrase that is used to generate your private
@@ -45,25 +45,25 @@ I have forgotten my password. What can I do?
 --------------------------------------------
 
 It is not possible to recover your password. However, you can restore
-your wallet from its seed phrase, and choose a new password. 
-If you lose both your password and your seed, there is no way 
+your wallet from its seed phrase and choose a new password.
+If you lose both your password and your seed, there is no way
 to recover your money. This is why we ask you to save your seed
 phrase on paper.
 
-To restore your wallet from seed phrase. Create a new wallet, select 
-the type, choose 'I already have a seed' and proceed to input your seed 
+To restore your wallet from its seed phrase, create a new wallet, select
+the type, choose "I already have a seed" and proceed to input your seed
 phrase.
 
 
 My transaction has been unconfirmed for a long time. What can I do?
 -------------------------------------------------------------------
 
-Bitcoin transactions become 'confirmed' when miners accept to write
+Bitcoin transactions become "confirmed" when miners accept to write
 them in the Bitcoin blockchain. In general, the speed of confirmation
 depends on the fee you attach to your transaction; miners prioritize
-transaction that pay the highest fees.
+transactions that pay the highest fees.
 
-Recent versions of Electrum use 'dynamic fees', in order to make sure
+Recent versions of Electrum use "dynamic fees" in order to make sure
 that the fee you pay with your transaction is adequate. This feature
 is enabled by default in recent versions of Electrum.
 
@@ -73,24 +73,24 @@ If you have made a transaction that is unconfirmed, you can:
    confirmed or cancelled. This might take several days.
 
  - Increase the transaction fee. This is only possible for
-   'replaceable' transactions. To create this type of transaction, you
-   must have enabled 'Replace by Fee' in your preferences, before
+   "replaceable" transactions. To create this type of transaction, you
+   must have enabled "Replace by Fee" in your preferences before
    sending the transaction.
 
- - Create a 'Child Pays For Parent' transaction. A CPFP is a new
-   transaction, that pays a high fee in order to compensate for the
+ - Create a "Child Pays for Parent" transaction. A CPFP is a new
+   transaction that pays a high fee in order to compensate for the
    small fee of its parent transaction. It can be done by the
    recipient of the funds, or by the sender, if the transaction has a
    change output.
 
 
-What does it mean to "Freeze" an address in Electrum?
+What does it mean to "freeze" an address in Electrum?
 -----------------------------------------------------
 
 When you freeze an address, the funds in that address will not be used
-for sending bitcoins. You can not send Bitcoins if you don't have
+for sending bitcoins. You cannot send bitcoins if you don't have
 enough funds in the non-frozen addresses.
-          
+
 
 How is the wallet encrypted?
 ----------------------------
@@ -119,7 +119,7 @@ requesting bitcoins on a wallet that you do not control.
 Does Electrum support cold wallets?
 -----------------------------------
 
-Yes. see :ref:`Cold Storage <coldstorage>`
+Yes, see :ref:`Cold Storage <coldstorage>`.
 
 
 Can I import private keys from other Bitcoin clients?
@@ -128,7 +128,7 @@ Can I import private keys from other Bitcoin clients?
 In Electrum 2.0, you cannot import private keys in a wallet that has a
 seed. You should sweep them instead.
 
-If you want to import private keys and not sweep them you need to
+If you want to import private keys and not sweep them, you need to
 create a special wallet that does not have a seed.  For this, create a
 new wallet, select "restore", and instead of typing your seed, type a
 list of private keys, or a list of addresses if you want to create a
@@ -139,7 +139,7 @@ watching-only wallet.
 
 
 You will need to back up this wallet, because it cannot be
-recovered from seed.
+recovered from a seed.
 
 Can I sweep private keys from other Bitcoin clients?
 ----------------------------------------------------
@@ -151,16 +151,16 @@ become a part of your wallet.  Instead, all the bitcoins they control
 are sent to an address that has been deterministically generated from
 your wallet seed.
 
-To sweep private keys go to Wallet menu -> Private Keys ->
+To sweep private keys, go to the Wallet menu -> Private Keys ->
 Sweep. Enter the private keys in the appropriate field. Leave the
-'Address' field unchanged. That is the destination address and it'll
+"Address" field unchanged. That is the destination address and it will
 be from your existing electrum wallet.
 
 Where is my wallet file located?
 --------------------------------
 
-The default wallet file is called default_wallet which is created when
-you first run the application and located under the /wallets folder.
+The default wallet file is called default_wallet, which is created when
+you first run the application and is located in the /wallets folder.
 
 On Windows:
 
@@ -189,7 +189,7 @@ each address and amount on a line, separated by a comma.
 Amounts are in the current unit set in the client. The
 total is shown in the GUI.
 
-You can also import a CSV file in the 'Pay to' field, by clicking on
+You can also import a CSV file in the "Pay to" field, by clicking on
 the folder icon.
 
 
@@ -199,17 +199,17 @@ Can Electrum create and sign raw transactions?
 Electrum lets you create and sign raw transactions right from the user
 interface using a form.
 
-Electrum freezes when I try to send bitcoins
+Electrum freezes when I try to send bitcoins.
 --------------------------------------------
 
 This might happen if you are trying to spend a large number of
-transactions outputs (for example, if you have collected hundreds of
-donations from a Bitcoin faucet).  When you send Bitcoins, Electrum
-looks for unspent coins that are in your wallet, in order to create a
+transaction outputs (for example, if you have collected hundreds of
+donations from a Bitcoin faucet). When you send Bitcoins, Electrum
+looks for unspent coins that are in your wallet in order to create a
 new transaction. Unspent coins can have different values, much like
 physical coins and bills.
 
-If this happens, you should consolidate your transaction inputs, by
+If this happens, you should consolidate your transaction inputs by
 sending smaller amounts of bitcoins to one of your wallet addresses;
 this would be the equivalent of exchanging a stack of nickels for a
 dollar bill.
@@ -220,31 +220,31 @@ What is the gap limit?
 ----------------------
 
 The gap limit is the maximum number of consecutive unused addresses in
-your deterministic sequence of addresses.  Electrum uses it in order
+your deterministic sequence of addresses. Electrum uses it in order
 to stop looking for addresses. In Electrum 2.0, it is set to 20 by
 default, so the client will get all addresses until 20 unused
 addresses are found.
-          
+
 
 How can I pre-generate new addresses?
 -------------------------------------
 
 Electrum will generate new addresses as you use them,
-until it hits the `gap limit`_
+until it hits the `gap limit`_.
 
 If you need to pre-generate more addresses, you can do so by typing
 wallet.create_new_address(False) in the console. This command will generate
 one new address. Note that the address will be shown with a red
-background in the address tab, to indicate that it is beyond the gap
+background in the address tab to indicate that it is beyond the gap
 limit. The red color will remain until the gap is filled.
 
 WARNING: Addresses beyond the gap limit will not automatically be
-recovered from seed. To recover them will require either increasing
+recovered from the seed. To recover them will require either increasing
 the client's gap limit or generating new addresses until the used
 addresses are found.
 
 
-If you wish to generate more than one address, you may use a 'for'
+If you wish to generate more than one address, you can use a "for"
 loop. For example, if you wanted to generate 50 addresses, you could
 do this:
 
@@ -254,8 +254,8 @@ do this:
 	print wallet.create_new_address(False)
 
 
-How to upgrade Electrum?
-------------------------
+How do I upgrade Electrum?
+--------------------------
 
 Warning: always save your wallet seed on paper before
 doing an upgrade.
@@ -271,7 +271,7 @@ Some Electrum upgrades will modify the format of your
 wallet files.
 
 For this reason, it is not recommended to downgrade
-Electrum to an older version, once you have opened your
+Electrum to an older version once you have opened your
 wallet file with the new version. The older version will
 not always be able to read the new wallet file.
 
@@ -289,9 +289,9 @@ Electrum 1.x wallets to Electrum 2.x:
   longer be able to use your wallet once the upgrade is
   complete.
 
-- The 'Addresses' tab will not show any addresses the
+- The "Addresses" tab will not show any addresses the
   first time you launch Electrum 2. This is expected
-  behaviour. Restart Electrum 2 after the upgrade is
+  behavior. Restart Electrum 2 after the upgrade is
   complete and your addresses will be available.
 
 - Offline copies of Electrum will not show the


### PR DESCRIPTION
I've made some minor changes for grammatical correctness and stylistic consistency.

Previously both single and double quotation marks were used. I've used double quotation marks throughout.

I also made the usage of "bitcoin" and "Bitcoin" consistent: The former refers to the unit of currency, while the latter refers to the protocol. Alternatively, "bitcoin" could be written lowercase in both cases, but the aforementioned usage seems to be more common (see [bitcoin.org](https://bitcoin.org/en/vocabulary#bitcoin)).