### PR TITLE
specify trezor version and include udev rules

### DIFF
--- a/hardware-linux.rst
+++ b/hardware-linux.rst
@@ -13,7 +13,7 @@ libraries bundled with it, so skip the first two steps.
 Currently all hardware wallets depend on ``hidapi``, to be able to build
 that, you need:
 
-*ubuntu:*
+*ubuntu/debian:*
 ::
 
    sudo apt-get install libusb-1.0-0-dev libudev-dev
@@ -37,7 +37,8 @@ Trezor
 
 ::
 
-   python3 -m pip install trezor[hidapi]
+   python3 -m pip install --user trezor[hidapi]==0.11.6
+   sudo wget -O /etc/udev/rules.d/51-trezor.rules https://raw.githubusercontent.com/trezor/trezor-common/master/udev/51-trezor.rules
 
 For more details, refer to `python-trezor <https://github.com/trezor/python-trezor>`_.
 


### PR DESCRIPTION
Electrum has restrictions for less than v0.12.0 of trezor package
![image](https://user-images.githubusercontent.com/6263105/80270729-9c0d1a00-8688-11ea-8e97-51047f0e3e2f.png)

Solution was to install the latest v0.11.x version, but I do wonder if the v0.12.0 restriction is unnecessary. Something for someone to look into.