### PR TITLE
Added "How does Electrum get the Bitcoin price?

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -101,6 +101,13 @@ the type, choose "I already have a seed" and proceed to input your seed
 phrase.
 
 
+How does Electrum get the Bitcoin price it uses?
+------------------------------------------------
+Electrum gets the Bitcoin price from a third party, but provides
+various options.  Please see menubar > `Tools` > `Preferences` > `Fiat`
+to view the current setting or choose a new one.
+
+
 My transaction has been unconfirmed for a long time. What can I do?
 -------------------------------------------------------------------
 


### PR DESCRIPTION
I don't have Electrum myself, but I sent a friend some Bitcoin using the price on Bitstamp and it let to a discussion and a search for how Electrum gets the price.  This seems like the right place to drop the information that @SomberNight gave me in [Electrum issue 7085 (closed)](https://github.com/spesmilo/electrum/issues/7085).