### PR TITLE
update HW on linux - add jade

### DIFF
--- a/hardware-linux.rst
+++ b/hardware-linux.rst
@@ -101,6 +101,15 @@ Coldcard
 
 For more details, refer to `ckcc-protocol <https://github.com/Coldcard/ckcc-protocol>`_.
 
+Jade
+^^^^^^^^
+
+::
+
+   python3 -m pip install pyserial && python3 -m pip install cbor
+
+For more details, refer to `jadepy <https://github.com/spesmilo/electrum/tree/master/electrum/plugins/jade/jadepy>`_.
+
 
 3. udev rules
 ~~~~~~~~~~~~~

--- a/hardware-linux.rst
+++ b/hardware-linux.rst
@@ -106,7 +106,7 @@ Jade
 
 ::
 
-   python3 -m pip install pyserial && python3 -m pip install cbor
+   python3 -m pip install pyserial cbor
 
 For more details, refer to `jadepy <https://github.com/spesmilo/electrum/tree/master/electrum/plugins/jade/jadepy>`_.
 


### PR DESCRIPTION
In order to use Jade HW on linux with electrum it needs to install two libraries, pyserial and cbor, both already listed on https://github.com/spesmilo/electrum/blob/master/contrib/requirements/requirements-hw.txt but not yet in documentation.