### PR TITLE
add dark mode theme via sphinx_rtd_dark_mode

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -40,6 +40,7 @@
 extensions = [
     "sphinx_rtd_theme",
     "myst_parser",
+    "sphinx_rtd_dark_mode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -124,6 +125,8 @@ def setup(app):
 # to template names.
 #
 
+# user starts in light mode
+default_dark_mode = False
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
 sphinx<9
 sphinx-rtd-theme<4
 myst-parser<5
+sphinx-rtd-dark-mode<2


### PR DESCRIPTION
Uses the https://github.com/MrDogeBro/sphinx_rtd_dark_mode sphinx extension to add a dark mode button to the docs.
Light mode stays the default.

Can be tested with:
```
pip install sphinx-rtd-dark-mode
sphinx-build -M html . _build
```