### PR TITLE
plugins: Update internal plugins, add table of external plugins

### DIFF
--- a/merchant.rst
+++ b/merchant.rst
@@ -1,9 +1,11 @@
+.. _merchant:
+
 How to accept Bitcoin on a website using Electrum
 =================================================
 
 This tutorial will show you how to accept Bitcoin on a website with
 SSL signed payment requests, according to BIP-70_. The docs are
-updated for Electrum 4.0 (currently in development_).
+updated for Electrum 4.0.
 
 .. _BIP-70:
     https://github.com/bitcoin/bips/blob/master/bip-0070.mediawiki

--- a/plugin_dev.rst
+++ b/plugin_dev.rst
@@ -1,3 +1,5 @@
+.. _plugin_dev:
+
 Electrum Plugin development
 ===========================
 

--- a/plugins.rst
+++ b/plugins.rst
@@ -32,6 +32,9 @@ Below you can find a short description of each integrated Tool.
 
 * Virtual Keyboard: Add an optional virtual keyboard to the password dialog.
 
+* Swapserver [CLI only]: Offer submarine swaps to other Electrum users. See: :ref:`Running a swapserver <swapserver>`
+
+* Payserver [CLI only]: Run a HTTP server for receiving payments. See :ref:`How to accept Bitcoin on a website <merchant>`.
 
 External Plugins
 ----------------

--- a/plugins.rst
+++ b/plugins.rst
@@ -80,6 +80,22 @@ On Windows
     .. image:: png/external_plugin_windows_regedit.png
         :align: center
 
+List of external plugins
+^^^^^^^^^^^^^^^^^^^^^^^^
+Below is a non-exhaustive list of known external plugins.
+
+These plugins are **not reviewed or endorsed by Electrum** and should be used **at your own risk**.
+
+
+.. csv-table:: :rst:dir:`List of external Electrum plugins`
+   :header: "Name", "Description", "Repository", "Added"
+
+    "Guardian", "`Physical coercion resistance <https://delvingbitcoin.org/t/proposal-guardian-address-gaspv1/2006>`_", "`Github Repository <https://github.com/bitcoinguardian/electrum/tree/master/electrum/plugins/guardian>`_", "10/2025"
+    "LNURL Server", "`Receive LN payments through a static URL <https://github.com/lnurl/luds/blob/luds/06.md>`_", "`Github Repository <https://github.com/f321x/electrum-lnurl-server>`_", "10/2025"
+    "Joinstr", "`Collaborative Transactions via Nostr <https://joinstr.xyz/>`_", "`Gitlab Repository <https://gitlab.com/invincible-privacy/joinstr/-/tree/main/plugin>`_", "10/2025"
+
+
+If you want to submit a plugin to be added to the list open a Pull Request on the `Electrum docs repository <https://github.com/spesmilo/electrum-docs/>`_.
 
 Plugin Development
 ------------------

--- a/ssl.rst
+++ b/ssl.rst
@@ -1,7 +1,7 @@
 How to configure SSL with Electrum
 ==================================
 
-This page was written for Electrum 4.0 (currently in development_)
+This page was written for Electrum 4.0.
 
 You should have a TLS/SSL private key and a public certificate for
 your domain set up already (signed by a CA, for example free Letsencrypt_)

--- a/swapserver.rst
+++ b/swapserver.rst
@@ -1,3 +1,5 @@
+.. _swapserver:
+
 How to offer Submarine Swaps
 ============================
 


### PR DESCRIPTION
Extend the list of internal plugins with the swapserver and payserver
plugins and link to their main docs pages.

Adds a table with external plugins so there is a place to collect
plugins in the future.